### PR TITLE
Display gitignore types on a new line.

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -2,6 +2,7 @@
 
 var GitIgnore = require('./library');
 var fs = require('fs');
+var OS = require('os');
 
 (function() {
   var type = process.argv[2];
@@ -28,7 +29,7 @@ var fs = require('fs');
         }
         return;
       }
-      console.log.apply(console.log, types);
+      console.log(types.join(OS.EOL));
     });
   } else {
     type = type.charAt(0).toUpperCase() + type.slice(1);


### PR DESCRIPTION
I tried using this module now and I noticed it was a bit difficult for me to see it the language I am working with was supported. This was because all the gitignore types was displayed on a new line.

I decided to contribute to this open source project by improving it and making it better.

Good job.