### PR TITLE
Add missing error callback

### DIFF
--- a/lib/library.js
+++ b/lib/library.js
@@ -10,7 +10,7 @@ GitIgnore.getTypes = function(callback){
     if (res.statusCode !== 200) {
       var err = new Error("somethingWentWrong");
       err.statusCode = res.statusCode;
-      return callback();
+      return callback(err);
     }
     var body = "";
     res.on("data", function(chunk) {


### PR DESCRIPTION
Pass the error to the callback in `getTypes` when `statusCode !== 200`.