### PR TITLE
[Docs] Use npx for cli tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Automatically fetch github's excellent `.gitignore` files for any of your new pr
 ### Install
 
     npm install gitignore -g
+    
+Note: If **[NPX](https://blog.npmjs.org/post/162869356040/introducing-npx-an-npm-package-runner)** (NPM's official package runner) is available in your environment you can use it to avoid a global install: ex. ```$ npx gitignore node``` is equivalent to ```npm i -g gitignore && gitignore node``` but avoids the global install step
 
 ### Usage
 


### PR DESCRIPTION
Adds note about using **[NPX](https://blog.npmjs.org/post/162869356040/introducing-npx-an-npm-package-runner)** with gitignore so users can avoid global install