### PR TITLE
Feature Flag options

### DIFF
--- a/lib/library.js
+++ b/lib/library.js
@@ -4,24 +4,24 @@ var https = require('https');
 
 var GitIgnore = {};
 
-GitIgnore.getTypes = function(callback){
+GitIgnore.getTypes = function (callback) {
   var types = [];
-  https.get({host: "api.github.com", path: "/repos/github/gitignore/contents", headers: {"User-Agent": "gitignore node app"}}, function(res) {
+  https.get({ host: "api.github.com", path: "/repos/github/gitignore/contents", headers: { "User-Agent": "gitignore node app" } }, function (res) {
     if (res.statusCode !== 200) {
       var err = new Error("somethingWentWrong");
       err.statusCode = res.statusCode;
       return callback(err);
     }
     var body = "";
-    res.on("data", function(chunk) {
+    res.on("data", function (chunk) {
       body += chunk;
     });
-    res.on("end", function() {
+    res.on("end", function () {
       var json = JSON.parse(body);
-      for(var i = 0; i < json.length; ++i) {
+      for (var i = 0; i < json.length; ++i) {
         var name = json[i].name;
         var cleanName = name.substr(0, name.indexOf('.'));
-        if (cleanName.length > 0 && name.match(/\.gitignore$/)){
+        if (cleanName.length > 0 && name.match(/\.gitignore$/)) {
           types.push(cleanName);
         }
       }
@@ -30,14 +30,14 @@ GitIgnore.getTypes = function(callback){
   }).on("error", callback);
 };
 
-GitIgnore.writeFile = function(options, callback){
-  if(!options.type){
+GitIgnore.writeFile = function (options, callback) {
+  if (!options.type) {
     return callback(new Error("noTypeProvided"));
   }
-  if(!options.file && !options.writable){
+  if (!options.file && !options.writable) {
     return callback(new Error("noWritableProvided"));
   }
-  https.get("https://raw.githubusercontent.com/github/gitignore/master/" + options.type + ".gitignore", function(res) {
+  https.get("https://raw.githubusercontent.com/github/gitignore/master/" + options.type + ".gitignore", function (res) {
     if (res.statusCode !== 200) {
       var err = new Error("typeDoesNotExist");
       err.statusCode = res.statusCode;
@@ -46,6 +46,22 @@ GitIgnore.writeFile = function(options, callback){
     res.pipe(options.file || options.writable);
     return callback();
   }).on("error", callback);
+};
+
+GitIgnore.writeFlag = function (options, callback) {
+  if (!options.flag) {
+    return callback(new Error("noFlagProvided"));
+  }
+  if (!options.file && !options.writable) {
+    return callback(new Error("noWritableProvided"));
+  }
+  if (options.flag == "--macos")
+    options.file.write(`\n# Desktop Service Store Mac \n.DS_Store \n\n`);
+  else if (options.flag == "--locks")
+    options.file.write(`\n# Lock Files \npackage-lock.json\nyarn.lock \n\n`);
+  else
+    return callback(new Error("WrongFlagProvided"));
+  return callback();
 };
 
 module.exports = GitIgnore;

--- a/lib/main.js
+++ b/lib/main.js
@@ -31,25 +31,44 @@ var OS = require('os');
   } else {
     types.forEach(function(type) {
       type = type.charAt(0).toUpperCase() + type.slice(1);
-      var file = fs.createWriteStream(".gitignore", {'flags': 'a'});
-      GitIgnore.writeFile({
-        type: type,
-        file: file
-      }, function(err){
-        if(err){
-          if(err.statusCode){
-            console.log("There is no gitignore for " + type);
-            console.log("Available project types can be found by running `gitignore -types` or at https://github.com/github/gitignore");
-            console.error("Recieved status code "+err.statusCode);
-          } else {
-            console.error("An unexpected error occurred.");
-            console.error(err);
+      let file = fs.createWriteStream(".gitignore", { 'flags': 'a' });
+      if (/--\w/.test(type)) {
+        GitIgnore.writeFlag({
+          flag: type,
+          file: file
+        }, function (err) {
+          if (err) {
+            if (err.statusCode) {
+              console.log("There is no gitignore for flag" + type);
+              console.error("Error code " + err.statusCode);
+            } else {
+              console.error("An unexpected error occurred.");
+              console.error(err);
+            }
+            return;
+          }          
+        });
+      }
+      else {
+        GitIgnore.writeFile({
+          type: type,
+          file: file
+        }, function(err){
+          if(err){
+            if(err.statusCode){
+              console.log("There is no gitignore for " + type);
+              console.log("Available project types can be found by running `gitignore -types` or at https://github.com/github/gitignore");
+              console.error("Recieved status code "+err.statusCode);
+            } else {
+              console.error("An unexpected error occurred.");
+              console.error(err);
+            }
+            return;
           }
-          return;
-        }
-        console.log("Created .gitignore file for type "+type+" :)");
-      });
+        });
+      }
     });
+    console.log(`Created .gitignore file for flag type ${types}.`);
   }
 
 }).call(this);


### PR DESCRIPTION
#21 
From this [issue](https://github.com/msfeldstein/gitignore/issues/19) I created a solution.
With the possibility to add inline options to the module  , now I already added the `MacOS` option and the`Locks` option.
This two option is described below :

1.  **Locks** , you can add `package-lock.json` and `yarn.lock` to the gitignore file with this command 
 For example : 
 ```bash
 gitignore node --locks
```
2. **MacOS**, you can add `.DS_Store`to the gitignore file with this command
For Example :
```bash
gitignore python --macos
```
 The name of the option it's a test , if you think it's correct ok , if not I can change it, don't worry.

With this new feature of the custom options you can implement new fuctionality to the module and I think it's very cool and useful for the developers community.

So tell me what do you think about this feature and the implementation.
Let me know

Thank You
@msfeldstein 